### PR TITLE
Adding responseFormats to the DemoController causes the map values to

### DIFF
--- a/grails-app/controllers/demo/DemoController.groovy
+++ b/grails-app/controllers/demo/DemoController.groovy
@@ -4,6 +4,9 @@ import org.springframework.http.HttpStatus
 
 class DemoController {
 
+    //This causes the values in the map object to render as null in the GSON view.
+    static responseFormats = ['json']
+
     def index() {
         respond([firstName: 'Jeff', submissionPackageId: 42l], status: HttpStatus.CREATED)
     }


### PR DESCRIPTION
render as null in the corresponding GSON view.

![beforeresponseformats](https://cloud.githubusercontent.com/assets/2530576/18800887/a0e035aa-81ad-11e6-8fbf-e2700824453b.PNG)
![afterresponseformats](https://cloud.githubusercontent.com/assets/2530576/18800890/a380ee3a-81ad-11e6-9746-72c91d96ba67.PNG)
